### PR TITLE
Updates for enterprise contract validation

### DIFF
--- a/.tekton/trustee-operator-bundle-pull-request.yaml
+++ b/.tekton/trustee-operator-bundle-pull-request.yaml
@@ -325,26 +325,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/trustee-operator-bundle-pull-request.yaml
+++ b/.tekton/trustee-operator-bundle-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: bundle.Dockerfile
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/trustee-operator-bundle-pull-request.yaml
+++ b/.tekton/trustee-operator-bundle-pull-request.yaml
@@ -22,6 +22,8 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: "true"
   - name: output-image
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator-bundle:on-pr-{{revision}}
   - name: image-expires-after

--- a/.tekton/trustee-operator-bundle-push.yaml
+++ b/.tekton/trustee-operator-bundle-push.yaml
@@ -322,26 +322,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/trustee-operator-bundle-push.yaml
+++ b/.tekton/trustee-operator-bundle-push.yaml
@@ -21,6 +21,8 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: "true"
   - name: output-image
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator-bundle:{{revision}}
   - name: dockerfile

--- a/.tekton/trustee-operator-bundle-push.yaml
+++ b/.tekton/trustee-operator-bundle-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator-bundle:{{revision}}
   - name: dockerfile
     value: bundle.Dockerfile
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
-  - prefetch-input
+  - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
+  - prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
@@ -112,7 +114,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "true"
+    - default: "false"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/trustee-operator-push.yaml
+++ b/.tekton/trustee-operator-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator:{{revision}}
   - name: revision
     value: '{{revision}}'
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
@@ -109,7 +111,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "true"
+    - default: "false"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/trustee-operator-push.yaml
+++ b/.tekton/trustee-operator-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator:{{revision}}
   - name: revision
     value: '{{revision}}'
+  - prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/trustee-operator-push.yaml
+++ b/.tekton/trustee-operator-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ose-osc-tenant/trustee/trustee-operator:{{revision}}
   - name: revision
     value: '{{revision}}'
-  - prefetch-input
+  - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     finally:

--- a/.tekton/trustee-operator-push.yaml
+++ b/.tekton/trustee-operator-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -23,9 +23,7 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ LABEL release="1"
 LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
+LABEL maintainer="Red Hat"
 
 # Licenses
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,7 @@ LABEL release="1"
 LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
+
+# Licenses
+
+COPY LICENSE /licenses/LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,20 @@ COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]
+
+# Red Hat labels.
+
+ARG NAME=trustee-operator
+ARG DESCRIPTION="The Trustee operator."
+
+LABEL com.redhat.component=$NAME
+LABEL description=$DESCRIPTION
+LABEL io.k8s.description=$DESCRIPTION
+LABEL io.k8s.display-name=$NAME
+LABEL name=$NAME
+LABEL summary=$DESCRIPTION
+LABEL distribution-scope=public
+LABEL release="1"
+LABEL url="https://access.redhat.com/"
+LABEL vendor="Red Hat, Inc."
+LABEL version="1"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,18 +36,6 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 
-LABEL features.operators.openshift.io/cnf="false"
-LABEL features.operators.openshift.io/cni="false"
-LABEL features.operators.openshift.io/csi="false"
-LABEL features.operators.openshift.io/disconnected="false"
-LABEL features.operators.openshift.io/fips-compliant="false"
-LABEL features.operators.openshift.io/proxy-aware="false"
-LABEL features.operators.openshift.io/tls-profiles="false"
-LABEL features.operators.openshift.io/token-auth-aws="false"
-LABEL features.operators.openshift.io/token-auth-azure="false"
-LABEL features.operators.openshift.io/token-auth-gcp="false"
-LABEL operators.openshift.io/valid-subscription="false"
-
 # Licenses
 
 COPY LICENSE /licenses/LICENSE

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -18,3 +18,32 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+# Red Hat labels.
+
+ARG NAME=trustee-operator-bundle
+ARG DESCRIPTION="The Trustee operator bundle."
+
+LABEL com.redhat.component=$NAME
+LABEL description=$DESCRIPTION
+LABEL io.k8s.description=$DESCRIPTION
+LABEL io.k8s.display-name=$NAME
+LABEL name=$NAME
+LABEL summary=$DESCRIPTION
+LABEL distribution-scope=public
+LABEL release="1"
+LABEL url="https://access.redhat.com/"
+LABEL vendor="Red Hat, Inc."
+LABEL version="1"
+
+LABEL features.operators.openshift.io/cnf="false"
+LABEL features.operators.openshift.io/cni="false"
+LABEL features.operators.openshift.io/csi="false"
+LABEL features.operators.openshift.io/disconnected="false"
+LABEL features.operators.openshift.io/fips-compliant="false"
+LABEL features.operators.openshift.io/proxy-aware="false"
+LABEL features.operators.openshift.io/tls-profiles="false"
+LABEL features.operators.openshift.io/token-auth-aws="false"
+LABEL features.operators.openshift.io/token-auth-azure="false"
+LABEL features.operators.openshift.io/token-auth-gcp="false"
+LABEL operators.openshift.io/valid-subscription="false"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -47,3 +47,7 @@ LABEL features.operators.openshift.io/token-auth-aws="false"
 LABEL features.operators.openshift.io/token-auth-azure="false"
 LABEL features.operators.openshift.io/token-auth-gcp="false"
 LABEL operators.openshift.io/valid-subscription="false"
+
+# Licenses
+
+COPY LICENSE /licenses/LICENSE

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -35,6 +35,7 @@ LABEL release="1"
 LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
+LABEL maintainer="Red Hat"
 
 # Licenses
 

--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -33,6 +33,17 @@ metadata:
     support: "Confidential Containers Community"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform"]'
   name: trustee-operator.v0.1.0
   namespace: placeholder
 spec:

--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: "Security"
-    containerImage: quay.io/confidential-containers/trustee-operator:v0.1.0
+    containerImage: quay.io/confidential-containers/trustee-operator:v0.1.0@sha256:9842d2fa531b5509b8a03096eec86e318e5c4fddeac01deaf528ab79da66f8c2
     createdAt: "2024-06-07T10:06:06Z"
     support: "Confidential Containers Community"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -184,7 +184,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -219,7 +219,7 @@ spec:
                   value: ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest
                 - name: RVPS_IMAGE_NAME
                   value: ghcr.io/confidential-containers/staged-images/rvps:latest
-                image: quay.io/confidential-containers/trustee-operator:v0.1.0
+                image: quay.io/confidential-containers/trustee-operator:v0.1.0@sha256:9842d2fa531b5509b8a03096eec86e318e5c4fddeac01deaf528ab79da66f8c2
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1@sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Dockerfile:
- Add labels.
- Add licenses directory.
- Use Red Hat UBI base images.

tekton:
- Enable the build source image.
- Remove preflight checks for operator bundle.
- Enable hermetic build.
- Enable prefetch go dependencies.

Other:
- Add feature annotations in the ClusterServiceVersion file.
- Pin images digest.