### PR TITLE
tekton: update cel expressions to avoid build loops

### DIFF
--- a/.tekton/trustee-operator-bundle-pull-request.yaml
+++ b/.tekton/trustee-operator-bundle-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && "bundle*".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: trustee

--- a/.tekton/trustee-operator-bundle-push.yaml
+++ b/.tekton/trustee-operator-bundle-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && "bundle*".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: trustee

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ! "bundle*".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: trustee

--- a/.tekton/trustee-operator-push.yaml
+++ b/.tekton/trustee-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ! "bundle*".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: trustee


### PR DESCRIPTION
- When bundle files change, build the bundle.
- Otherwise, build the operator.

The components relationship on Konflux are configured so that, when the operator changes, a successful operator build will trigger a pull request to update the image references in the bundle. That in turn will trigger a bundle build. See https://konflux-ci.dev/docs/how-tos/configuring/component-nudges/.

We should avoid changing both the operator and the bundle at the same time.