### PR TITLE
bundle: update image urls to use downstream

### DIFF
--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: "Security"
-    containerImage: quay.io/confidential-containers/trustee-operator:v0.1.0@sha256:9842d2fa531b5509b8a03096eec86e318e5c4fddeac01deaf528ab79da66f8c2
+    containerImage: registry.stage.redhat.io/confidential-compute-attestation-tech-preview/trustee-rhel9-operator@adf00e7620de206ca4b6cdc93495506b02c3af62525668980305ab3a2a594d12
     createdAt: "2024-06-07T10:06:06Z"
     support: "Confidential Containers Community"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
@@ -225,12 +225,12 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: KBS_IMAGE_NAME
-                  value: quay.io/confidential-containers/trustee:290fd0eb64ab20f50efbd27cf80542851c0ee17f
+                  value: registry.stage.redhat.io/confidential-compute-attestation-tech-preview/trustee-rhel9@sha256:f9a01814a01ff2dc45c20d70c288c50ffc731c0471c89e3786c98342e2d8583b
                 - name: AS_IMAGE_NAME
                   value: ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest
                 - name: RVPS_IMAGE_NAME
                   value: ghcr.io/confidential-containers/staged-images/rvps:latest
-                image: quay.io/confidential-containers/trustee-operator:v0.1.0@sha256:9842d2fa531b5509b8a03096eec86e318e5c4fddeac01deaf528ab79da66f8c2
+                image: registry.stage.redhat.io/confidential-compute-attestation-tech-preview/trustee-rhel9-operator@sha256:adf00e7620de206ca4b6cdc93495506b02c3af62525668980305ab3a2a594d12
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
These should be updated with automatic pull requests from Konflux. See https://konflux-ci.dev/docs/how-tos/configuring/component-nudges/.