### PR TITLE
fix(KONFLUX-3663): format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -388,10 +388,14 @@ spec:
         values:
         - 'false'
       runAfter:
-      - clone-repository
+      - build-container
       params:
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       taskRef:
         resolver: bundles


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for
long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263