### PR TITLE
bundle: declare supported architectures

### DIFF
--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -24,6 +24,10 @@ metadata:
     repository: https://github.com/openshift/trustee-operator
   name: trustee-operator.v0.1.0
   namespace: placeholder
+  labels:
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/tests/integration-tests.yaml
+++ b/tests/integration-tests.yaml
@@ -36,11 +36,11 @@ spec:
           script: |
             dnf -y install jq
             echo -e "Example test task for the Snapshot:\n ${SNAPSHOT}"
-            // Run custom tests for the given Snapshot here
-            // After the tests finish, record the overall result in the RESULT variable
+            # Run custom tests for the given Snapshot here
+            # After the tests finish, record the overall result in the RESULT variable
             RESULT="SUCCESS"
 
-            // Output the standardized TEST_OUTPUT result in JSON form
+            # Output the standardized TEST_OUTPUT result in JSON form
             TEST_OUTPUT=$(jq -rc --arg date $(date +%s) --arg RESULT "${RESULT}" --null-input \
               '{result: $RESULT, timestamp: $date, failures: 0, successes: 1, warnings: 0}')
             echo -n "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)


### PR DESCRIPTION
Add labels in the CSV, for Operator Hub to know which architectures we support.