### PR TITLE
Removal of ReadOnly part for PVCVolume

### DIFF
--- a/internal/controller/volumes.go
+++ b/internal/controller/volumes.go
@@ -139,7 +139,6 @@ func (r *KbsConfigReconciler) createPVCVolume(ctx context.Context, volumeName st
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: volumeName,
-				ReadOnly:  true,
 			},
 		},
 	}


### PR DESCRIPTION
While testing remote attestation for IBM SE, we were hit one scenario of key fetching failure. After multiple debugging, we found that it is having permission issue because of below - 
```
- name: ibmse-pvc-1oct-new
        persistentVolumeClaim:
          claimName: ibmse-pvc-1oct-new
          **readOnly: true** // This is creating permission issue from fetching the mounted path
```
After removal from deployment, the keys were accessible. Below was the sample result :- 

[```
root@a3elp36 gaurav-fresh-setup]# oc  exec -it kbs-client -- kbs-client  --url http://kbs-service:8080 get-resource --path default/kbsres1/key1
XXXXXXXXXXX 
[root@a3elp36 gaurav-fresh-setup]# oc  exec -it kbs-client -- kbs-client  --url http://kbs-service:8080 get-resource --path default/kbsres1/key2
XXXXXXXXXXX
```