### PR TITLE
tests: Use kata-cc runtimeclass name

### DIFF
--- a/scripts/install-helpers/tests/runtimeclass_workloads/pod-attestable.yaml.in
+++ b/scripts/install-helpers/tests/runtimeclass_workloads/pod-attestable.yaml.in
@@ -7,7 +7,7 @@ kind: Pod
 metadata:
   name: aa-test-cc
 spec:
-  runtimeClassName: kata-${TEE}
+  runtimeClassName: kata-cc
   containers:
     - name: bash-curl
       image: quay.io/kata-containers/alpine-bash-curl:latest

--- a/scripts/install-helpers/tests/runtimeclass_workloads/pod-confidential-unencrypted.yaml.in
+++ b/scripts/install-helpers/tests/runtimeclass_workloads/pod-confidential-unencrypted.yaml.in
@@ -25,7 +25,7 @@ spec:
       labels:
         app: "confidential-unencrypted"
     spec:
-      runtimeClassName: kata-${TEE}
+      runtimeClassName: kata-cc
       containers:
       - name: "confidential-unencrypted"
         image: ghcr.io/kata-containers/test-images:unencrypted-nightly

--- a/scripts/install-helpers/tests/runtimeclass_workloads/pod-signed-tests.yaml.in
+++ b/scripts/install-helpers/tests/runtimeclass_workloads/pod-signed-tests.yaml.in
@@ -10,7 +10,7 @@ metadata:
   annotations:
     io.katacontainers.config.hypervisor.kernel_params: "${KERNEL_PARAMS}"
 spec:
-  runtimeClassName: kata-${TEE}
+  runtimeClassName: kata-cc
   containers:
     - name: test-signed-image
       image: ${CONTAINER_IMAGE}


### PR DESCRIPTION
As we no longer ship kata-tdx / kata-snp, but rather a kata-cc one.