### PR TITLE
Set Default policy to allow

### DIFF
--- a/scripts/install-helpers/resource-policy-cm.yaml
+++ b/scripts/install-helpers/resource-policy-cm.yaml
@@ -6,7 +6,4 @@ metadata:
 data:
   policy.rego: |
     package policy
-    default allow = false
-    allow {
-      input["submods"]["cpu"]["ear.status"] != "contraindicated"
-    }
+    default allow = true


### PR DESCRIPTION
This is to avoid AMD key server throttling issue which is caused due to PolicyDeny error and subsequent requests to the Key server in a short span of time.

Fixes: #KATA-3895