### PR TITLE
Fix typo for trustee replicas configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ type KbsConfigSpec struct {
   kbsLocalCertCacheSpec kbsLocalCertCacheSpec `json:"kbsLocalCertCacheSpec,omitempty"`  
 
 	// KbsDeploymentSpec is the struct for trustee deployment options
-	KbsDeploymentSpec KbsDeploymentSpec `json:"KksDeploymentSpec,omitempty"`
+	KbsDeploymentSpec KbsDeploymentSpec `json:"KbsDeploymentSpec,omitempty"`
 }
 
 // IbmSEConfigSpec defines the desired state for IBMSE configuration

--- a/api/v1alpha1/kbsconfig_types.go
+++ b/api/v1alpha1/kbsconfig_types.go
@@ -141,7 +141,7 @@ type KbsConfigSpec struct {
 	KbsLocalCertCacheSpec KbsLocalCertCacheSpec `json:"kbsLocalCertCacheSpec,omitempty"`
 
 	// KbsDeploymentSpec is the struct for trustee deployment options
-	KbsDeploymentSpec KbsDeploymentSpec `json:"KksDeploymentSpec,omitempty"`
+	KbsDeploymentSpec KbsDeploymentSpec `json:"KbsDeploymentSpec,omitempty"`
 }
 
 // KbsConfigStatus defines the observed state of KbsConfig

--- a/bundle/manifests/confidentialcontainers.org_kbsconfigs.yaml
+++ b/bundle/manifests/confidentialcontainers.org_kbsconfigs.yaml
@@ -39,14 +39,7 @@ spec:
           spec:
             description: KbsConfigSpec defines the desired state of KbsConfig
             properties:
-              KbsEnvVars:
-                additionalProperties:
-                  type: string
-                description: |-
-                  KbsEnvVars injects environment variables in the trustee pods
-                  For example, RUST_LOG=debug enables logging with DEBUG severity
-                type: object
-              KksDeploymentSpec:
+              KbsDeploymentSpec:
                 description: KbsDeploymentSpec is the struct for trustee deployment
                   options
                 properties:
@@ -56,6 +49,13 @@ spec:
                       zero and not specified. Defaults to 1.
                     format: int32
                     type: integer
+                type: object
+              KbsEnvVars:
+                additionalProperties:
+                  type: string
+                description: |-
+                  KbsEnvVars injects environment variables in the trustee pods
+                  For example, RUST_LOG=debug enables logging with DEBUG severity
                 type: object
               ibmSEConfigSpec:
                 description: IbmSEConfigSpec is the struct that hosts the IBMSE specific

--- a/config/crd/bases/confidentialcontainers.org_kbsconfigs.yaml
+++ b/config/crd/bases/confidentialcontainers.org_kbsconfigs.yaml
@@ -39,14 +39,7 @@ spec:
           spec:
             description: KbsConfigSpec defines the desired state of KbsConfig
             properties:
-              KbsEnvVars:
-                additionalProperties:
-                  type: string
-                description: |-
-                  KbsEnvVars injects environment variables in the trustee pods
-                  For example, RUST_LOG=debug enables logging with DEBUG severity
-                type: object
-              KksDeploymentSpec:
+              KbsDeploymentSpec:
                 description: KbsDeploymentSpec is the struct for trustee deployment
                   options
                 properties:
@@ -56,6 +49,13 @@ spec:
                       zero and not specified. Defaults to 1.
                     format: int32
                     type: integer
+                type: object
+              KbsEnvVars:
+                additionalProperties:
+                  type: string
+                description: |-
+                  KbsEnvVars injects environment variables in the trustee pods
+                  For example, RUST_LOG=debug enables logging with DEBUG severity
                 type: object
               ibmSEConfigSpec:
                 description: IbmSEConfigSpec is the struct that hosts the IBMSE specific

--- a/tests/e2e/sample-attester/08-assert.yaml
+++ b/tests/e2e/sample-attester/08-assert.yaml
@@ -4,4 +4,4 @@ metadata:
   name: trustee-deployment
   namespace: trustee-operator-system
 status:
-  readyReplicas: 1
+  readyReplicas: 2

--- a/tests/e2e/sample-attester/08-kbsconfig_sample.yaml
+++ b/tests/e2e/sample-attester/08-kbsconfig_sample.yaml
@@ -23,3 +23,6 @@ spec:
   kbsLocalCertCacheSpec:
     secretName: vcek-secret
     mountPath: "/etc/kbs/snp/ek"
+  KbsDeploymentSpec:
+    replicas: 2
+


### PR DESCRIPTION
Since this typo is affecting the trustee configuration (and documentation), it is worth to backport the fix for v0.4.0