### PR TITLE
Re-added PCR 3, 8, 9 and 12 to azure SNP/TDX

### DIFF
--- a/config/templates/ear_default_attestation_policy_cpu.rego
+++ b/config/templates/ear_default_attestation_policy_cpu.rego
@@ -227,7 +227,11 @@ executables := 3 if {
   input.az_snp_vtpm
 
   input.az_snp_vtpm.measurement in query_reference_value("measurement")
+  input.az_snp_vtpm.tpm.pcr03 in query_reference_value("snp_pcr03")
+  input.az_snp_vtpm.tpm.pcr08 in query_reference_value("snp_pcr08")
+  input.az_snp_vtpm.tpm.pcr09 in query_reference_value("snp_pcr09")
   input.az_snp_vtpm.tpm.pcr11 in query_reference_value("snp_pcr11")
+  input.az_snp_vtpm.tpm.pcr12 in query_reference_value("snp_pcr12")
 }
 
 hardware := 2 if {
@@ -259,7 +263,11 @@ configuration := 2 if {
 executables := 3 if {
   input.az_tdx_vtpm
 
+  input.az_tdx_vtpm.tpm.pcr03 in query_reference_value("tdx_pcr03")
+  input.az_tdx_vtpm.tpm.pcr08 in query_reference_value("tdx_pcr08")
+  input.az_tdx_vtpm.tpm.pcr09 in query_reference_value("tdx_pcr09")
   input.az_tdx_vtpm.tpm.pcr11 in query_reference_value("tdx_pcr11")
+  input.az_tdx_vtpm.tpm.pcr12 in query_reference_value("tdx_pcr12")
 }
 
 hardware := 2 if {


### PR DESCRIPTION
The above PCR checks are being restored back as it was in v1.0.0