### PR TITLE
Update resource-policy

### DIFF
--- a/config/templates/resource-policy-restrictive.rego
+++ b/config/templates/resource-policy-restrictive.rego
@@ -2,14 +2,39 @@ package policy
 import rego.v1
 
 default allow = false
+default hardware_failing = false
 
 allow if {
-    not any_not_affirming
     count(input.submods) > 0
-
+    not executable_failing
+    not configuration_failing
+    not hardware_failing
 }
 
-any_not_affirming if {
+executable_failing if {
     some _, submod in input.submods
-    submod["ear.status"] != "affirming"
+    executables := submod["ear.trustworthiness-vector"]["executables"]
+    not in_affirming_range(executables)
+}
+
+configuration_failing if {
+    some _, submod in input.submods
+    configuration := submod["ear.trustworthiness-vector"]["configuration"]
+    not in_affirming_range(configuration)
+}
+
+# Hardware trust claims are enforced by default. For TDX, no additional
+# RVPS values are needed. For SNP, you must provide hardware-specific
+# RVPS values (tcb_bootloader, tcb_microcode, tcb_snp, tcb_tee) from
+# your environment. If these values are not available, comment out
+# the following block.
+hardware_failing if {
+   some _, submod in input.submods
+   hardware := submod["ear.trustworthiness-vector"]["hardware"]
+   not in_affirming_range(hardware)
+}
+
+in_affirming_range(val) if {
+    val >= 2
+    val <= 31
 }


### PR DESCRIPTION
Explicit checks for configuration, executables and hardware. Hardware check might need to be commented out for bare metal SNP in case of unknown HW reference values