### PR TITLE
airgap: enable disconnected installation for Trustee operator

### DIFF
--- a/docs/disconnected/README.md
+++ b/docs/disconnected/README.md
@@ -1,0 +1,43 @@
+# Disconnected Installation
+
+This directory contains `ImageSetConfiguration` files for mirroring the
+Trustee operator in disconnected (air-gapped) environments using `oc-mirror`.
+
+## What is covered
+
+Each `imageset-config-<ocp-version>.yaml` file mirrors:
+
+- The Trustee operator from the Red Hat operator catalog, including the
+  catalog index, operator bundle, and operator controller image.
+- The KBS operand image, listed as `relatedImages` in the operator bundle
+  and automatically picked up by `oc-mirror`.
+
+One file is provided per supported OCP version.
+
+## Usage
+
+1. Select the file matching your OCP version, e.g. `imageset-config-4.17.yaml`.
+
+2. Edit the `imageURL` field to point to your internal registry:
+
+   ```yaml
+   storageConfig:
+     registry:
+       imageURL: <your-registry>/mirror/oc-mirror-metadata
+   ```
+
+3. Run `oc-mirror` to mirror all images to your internal registry:
+
+   ```bash
+   oc-mirror --config imageset-config-4.17.yaml docker://<your-registry>
+   ```
+
+4. Apply the generated IDMS (ImageDigestMirrorSet) / ICSP (ImageContentSourcePolicy)
+   manifests to your cluster. These remap image references from upstream
+   registries to your internal mirror:
+
+   ```bash
+   oc apply -f oc-mirror-workspace/results-*/
+   ```
+
+5. Install the operator using the mirrored catalog as the source.

--- a/docs/disconnected/imageset-config-4.17.yaml
+++ b/docs/disconnected/imageset-config-4.17.yaml
@@ -1,0 +1,18 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    # URL of your internal registry where oc-mirror will store its metadata
+    # and push the mirrored images.
+    imageURL: <your-registry>/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.17.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.17
+    packages:
+    - name: trustee-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.18.yaml
+++ b/docs/disconnected/imageset-config-4.18.yaml
@@ -1,0 +1,18 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    # URL of your internal registry where oc-mirror will store its metadata
+    # and push the mirrored images.
+    imageURL: <your-registry>/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.18.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    packages:
+    - name: trustee-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.19.yaml
+++ b/docs/disconnected/imageset-config-4.19.yaml
@@ -1,0 +1,18 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    # URL of your internal registry where oc-mirror will store its metadata
+    # and push the mirrored images.
+    imageURL: <your-registry>/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.19.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
+    packages:
+    - name: trustee-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.20.yaml
+++ b/docs/disconnected/imageset-config-4.20.yaml
@@ -1,0 +1,18 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    # URL of your internal registry where oc-mirror will store its metadata
+    # and push the mirrored images.
+    imageURL: <your-registry>/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.20.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
+    packages:
+    - name: trustee-operator
+      channels:
+      - name: stable

--- a/docs/disconnected/imageset-config-4.21.yaml
+++ b/docs/disconnected/imageset-config-4.21.yaml
@@ -1,0 +1,18 @@
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v1alpha2
+storageConfig:
+  registry:
+    # URL of your internal registry where oc-mirror will store its metadata
+    # and push the mirrored images.
+    imageURL: <your-registry>/mirror/oc-mirror-metadata
+    skipTLS: false
+mirror:
+  operators:
+  - # Red Hat's official OLM catalog index for OCP 4.21.
+    # oc-mirror will automatically mirror the catalog index, the operator
+    # bundle, and all images listed as relatedImages in the bundle.
+    catalog: registry.redhat.io/redhat/redhat-operator-index:v4.21
+    packages:
+    - name: trustee-operator
+      channels:
+      - name: stable


### PR DESCRIPTION
To install Trustee in disconnected environments, users need an ImageSetConfiguration for oc-mirror and all operand images listed in the bundle. This PR adds both.

Tested locally with --dry-run. Planning to validate on a real disconnected cluster once the first round of review is in place.