### PR TITLE
fix: update CPE label to match prodsec release data

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,7 +36,7 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
-LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.0::el9"
+LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.101::el9"
 
 # Licenses
 


### PR DESCRIPTION
Update the CPE version from 1.0 to 1.101 to match the value assigned by prodsec in the release data file. The check-labels task validates that the image's cpe label matches the expected value from the data file.

CPE version convention for trustee:
  1.101 for release 1.1
  1.102 for release 1.2
  1.103 for release 1.3
  and so on.

For further reference on prodsec change, please see https://gitlab.cee.redhat.com/releng/konflux-release-data/-/commit/7482ed5a3bc8aaa0b7894bf1253614fbb944ee1d

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com
Signed-off-by: Daniel Kreling <dkreling@redhat.com>