### PR TITLE
fix: add CPE label to operator Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ LABEL vendor="Red Hat, Inc."
 LABEL version="1.1.0"
 LABEL maintainer="Red Hat"
 LABEL io.openshift.tags=""
+LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.101::el9"
 
 # Licenses
 


### PR DESCRIPTION
The operator Dockerfile had no explicit cpe label, so it inherited cpe:/a:redhat:enterprise_linux:9::appstream from the UBI9 base image. This caused the check-labels task to fail because it didn't match the prodsec-assigned value in the release data file.

CPE version convention for trustee:
  1.101 for release 1.1
  1.102 for release 1.2
  1.103 for release 1.3
  and so on.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Daniel Kreling <dkreling@redhat.com>