### PR TITLE
fix: enable package registry proxy for prefetch-dependencies

### DIFF
--- a/.tekton/trustee-operator-bundle-pull-request.yaml
+++ b/.tekton/trustee-operator-bundle-pull-request.yaml
@@ -169,6 +169,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/trustee-operator-bundle-push.yaml
+++ b/.tekton/trustee-operator-bundle-push.yaml
@@ -171,6 +171,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -186,6 +186,8 @@ spec:
         value: $(params.image-expires-after)
       - name: dev-package-managers
         value: "true"
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/trustee-operator-push.yaml
+++ b/.tekton/trustee-operator-push.yaml
@@ -183,6 +183,8 @@ spec:
         value: $(params.image-expires-after)
       - name: dev-package-managers
         value: "true"
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:


### PR DESCRIPTION
Set enable-package-registry-proxy to true in all prefetch-dependencies tasks to satisfy the prefetch_dependencies.package_registry_proxy_enabled EC policy, effective since 2026-05-13.