### PR TITLE
Upgrade procedure

### DIFF
--- a/docs/upgrade-v1.1-to-v1.2.md
+++ b/docs/upgrade-v1.1-to-v1.2.md
@@ -1,0 +1,69 @@
+# Upgrading from v1.1.0 to v1.2.0+
+
+## Overview
+
+Version 1.2.0 introduces automatic ConfigMap migration to provide a **zero-downtime, seamless upgrade experience** from v1.1.0.
+
+## What Changed
+
+### Configuration Format Changes
+
+1. **Storage Directory Consolidation**
+   - All storage moved to `/opt/confidential-containers/storage/`
+   - Old: `/opt/confidential-containers/kbs/repository`
+   - New: `/opt/confidential-containers/storage/repository`
+
+2. **RVPS Storage Format**
+   - Old: Single JSON file with array structure
+   - New: Directory-based storage with object structure
+
+3. **ConfigMap Key Names**
+   - Resource policy: `policy.rego` → `resource-policy.rego`
+   - RVPS reference values: `reference-values.json` → `reference_value`
+
+### What's Handled Automatically
+
+The operator **automatically detects and migrates** old ConfigMap formats during reconciliation:
+
+✅ Detects v1.1 ConfigMap format (deprecated fields, missing v1.2 fields)  
+✅ **Creates backup ConfigMaps** with `.v1.1` suffix before any destructive operations  
+✅ **RVPS and KBS Config**: Migrates content with format transformations  
+✅ **Policy ConfigMaps** (resource, CPU, GPU): Deletes and recreates with fresh content  
+✅ Adds migration annotation to track what's been migrated  
+✅ Triggers pod restart to apply new configuration  
+✅ Logs migration activity in operator logs  
+✅ **Preserves backups** for safety and manual recovery if needed  
+
+**Note**: Policy ConfigMaps (resource-policy, attestation-policy-cpu, attestation-policy-gpu) 
+are regenerated during migration to ensure they match the current profile settings. 
+Any customizations to these policies should be reapplied after migration.
+
+### Backup ConfigMaps
+
+For safety, the operator creates backup copies of all ConfigMaps before migration:
+
+- **Naming**: Backups have `.v1.1` suffix (e.g., `kbs-config.v1.1`)
+- **Metadata**: Each backup includes annotations tracking the original ConfigMap name and timestamp
+- **Preserved**: Backups are kept after successful migration for manual recovery if needed
+- **Cleanup**: Administrators can manually delete backups once they're confident the migration succeeded
+
+To list all backup ConfigMaps:
+```bash
+kubectl get configmap -n trustee-operator-system | grep '\.v1\.1$'
+```
+
+To restore from a backup (if needed):
+```bash
+# Get the backup
+kubectl get configmap <name>.v1.1 -n trustee-operator-system -o yaml > backup.yaml
+
+# Edit to remove .v1.1 from the name and restore
+sed -i 's/\.v1\.1$//' backup.yaml
+kubectl apply -f backup.yaml
+```
+
+To clean up backups after confirming migration success:
+```bash
+kubectl delete configmap -n trustee-operator-system -l 'kbs.confidentialcontainers.org/backup-of'
+# Or manually: kubectl delete configmap <name>.v1.1 -n trustee-operator-system
+```  

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -123,6 +123,16 @@ func (r *KbsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// Migrate ConfigMaps if needed (upgrade from v1.1.0 to v1.2.0+)
+	// This ensures seamless upgrades without requiring manual ConfigMap deletion
+	err = r.migrateConfigMapsIfNeeded(ctx)
+	if err != nil {
+		r.log.Info("ConfigMap migration encountered an error, will retry", "err", err)
+		// Don't fail the reconciliation, just requeue to retry migration later
+		// This prevents blocking the entire deployment if migration has transient issues
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	// Create or update the KBS deployment
 	created, err := r.deployOrUpdateKbsDeployment(ctx)
 	if err != nil {

--- a/internal/controller/migration.go
+++ b/internal/controller/migration.go
@@ -1,0 +1,613 @@
+/*
+Copyright Confidential Containers Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// Annotation to mark ConfigMaps that have been migrated
+	MigrationAnnotation = "kbs.confidentialcontainers.org/migrated-from-v1.1.0"
+	MigrationVersion    = "v1.2.0"
+	// Suffix for backup ConfigMaps created during migration
+	BackupSuffix = ".v1.1"
+)
+
+// migrateConfigMapsIfNeeded checks for old ConfigMap formats and migrates them automatically
+// This provides a seamless upgrade path from v1.1.0 to v1.2.0+
+func (r *KbsConfigReconciler) migrateConfigMapsIfNeeded(ctx context.Context) error {
+	r.log.Info("Checking for ConfigMap migrations")
+
+	// Migrate KBS config TOML ConfigMap (most critical - has TOML structure changes)
+	if r.kbsConfig.Spec.KbsConfigMapName != "" {
+		err := r.migrateKbsConfigMap(ctx)
+		if err != nil {
+			r.log.Info("Failed to migrate KBS config ConfigMap", "err", err)
+			return err
+		}
+	}
+
+	// Migrate RVPS reference values ConfigMap
+	if r.kbsConfig.Spec.KbsRvpsRefValuesConfigMapName != "" {
+		err := r.migrateRvpsConfigMap(ctx)
+		if err != nil {
+			r.log.Info("Failed to migrate RVPS ConfigMap", "err", err)
+			return err
+		}
+	}
+
+	// Migrate resource policy ConfigMap
+	if r.kbsConfig.Spec.KbsResourcePolicyConfigMapName != "" {
+		err := r.migrateResourcePolicyConfigMap(ctx)
+		if err != nil {
+			r.log.Info("Failed to migrate resource policy ConfigMap", "err", err)
+			return err
+		}
+	}
+
+	// Migrate attestation policy ConfigMap
+	if r.kbsConfig.Spec.KbsAttestationPolicyConfigMapName != "" {
+		err := r.migrateAttestationPolicyConfigMap(ctx)
+		if err != nil {
+			r.log.Info("Failed to migrate attestation policy ConfigMap", "err", err)
+			return err
+		}
+	}
+
+	// Migrate GPU attestation policy ConfigMap
+	if r.kbsConfig.Spec.KbsGpuAttestationPolicyConfigMapName != "" {
+		err := r.migrateGpuAttestationPolicyConfigMap(ctx)
+		if err != nil {
+			r.log.Info("Failed to migrate GPU attestation policy ConfigMap", "err", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// migrateKbsConfigMap migrates the KBS config by:
+// 1. Creating a backup ConfigMap with .v1.1 suffix
+// 2. Deleting the original ConfigMap
+// 3. On next reconciliation, merging plugins from backup into recreated v1.2 ConfigMap
+// 4. Deleting the backup ConfigMap after successful merge
+func (r *KbsConfigReconciler) migrateKbsConfigMap(ctx context.Context) error {
+	configMap := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{
+		Namespace: r.namespace,
+		Name:      r.kbsConfig.Spec.KbsConfigMapName,
+	}, configMap)
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// ConfigMap doesn't exist - check if we have a backup to merge
+			backupName := r.kbsConfig.Spec.KbsConfigMapName + BackupSuffix
+			backupConfigMap := &corev1.ConfigMap{}
+			backupErr := r.Get(ctx, client.ObjectKey{
+				Namespace: r.namespace,
+				Name:      backupName,
+			}, backupConfigMap)
+
+			if backupErr == nil {
+				r.log.Info("KBS config ConfigMap not found but backup exists - waiting for recreation")
+				// ConfigMap will be recreated by TrusteeConfig controller
+				// We'll merge plugins in the next reconciliation
+				return nil
+			}
+
+			r.log.V(1).Info("KBS config ConfigMap not found, skipping migration")
+			return nil
+		}
+		return err
+	}
+
+	// Check if already migrated
+	if configMap.Annotations != nil {
+		if _, exists := configMap.Annotations[MigrationAnnotation]; exists {
+			r.log.V(1).Info("KBS config ConfigMap already migrated", "name", configMap.Name)
+			return nil
+		}
+	}
+
+	// Check if we have a backup from a previous migration attempt
+	backupName := r.kbsConfig.Spec.KbsConfigMapName + BackupSuffix
+	backupConfigMap := &corev1.ConfigMap{}
+	backupErr := r.Get(ctx, client.ObjectKey{
+		Namespace: r.namespace,
+		Name:      backupName,
+	}, backupConfigMap)
+
+	if backupErr == nil {
+		// We have a backup and the ConfigMap exists (recreated by TrusteeConfig)
+		// This means we're in step 2: merge plugins from backup
+		r.log.Info("Merging plugins from backup into recreated v1.2 KBS config", "name", configMap.Name, "backup", backupName)
+		return r.mergePluginsFromBackup(ctx, configMap, backupConfigMap)
+	}
+
+	// This is step 1: Create backup and delete original ConfigMap
+	if _, hasToml := configMap.Data["kbs-config.toml"]; !hasToml {
+		r.log.V(1).Info("KBS config ConfigMap has no kbs-config.toml, adding migration annotation", "name", configMap.Name)
+		return r.addMigrationAnnotation(ctx, configMap)
+	}
+
+	r.log.Info("Creating backup of v1.1 KBS config for migration", "name", configMap.Name, "backup", backupName)
+
+	// Create backup ConfigMap
+	err = r.createConfigMapBackup(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to create backup of KBS config ConfigMap: %w", err)
+	}
+
+	r.log.Info("Backup created, deleting original ConfigMap", "name", configMap.Name)
+
+	// Delete the ConfigMap so TrusteeConfig recreates it in v1.2 format
+	err = r.Delete(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to delete KBS config ConfigMap for migration: %w", err)
+	}
+
+	r.log.Info("Deleted KBS config ConfigMap for v1.2 recreation", "name", configMap.Name)
+	r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "ConfigMapDeleted",
+		"ConfigMapMigration", "Deleted KBS config ConfigMap %s - will recreate in v1.2 format and merge plugins from backup %s", configMap.Name, backupName)
+
+	return nil
+}
+
+// extractPluginsSections extracts all [[plugins]] sections from v1.1 TOML
+// Returns a slice of plugin section strings
+func extractPluginsSections(toml string) []string {
+	var plugins []string
+	lines := strings.Split(toml, "\n")
+	var currentPlugin []string
+	inPlugin := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check if this is the start of a [[plugins]] section
+		if trimmed == "[[plugins]]" {
+			// Save previous plugin if exists
+			if inPlugin && len(currentPlugin) > 0 {
+				plugins = append(plugins, strings.Join(currentPlugin, "\n"))
+			}
+			// Start new plugin
+			currentPlugin = []string{line}
+			inPlugin = true
+			continue
+		}
+
+		// If we're in a plugin section
+		if inPlugin {
+			// Check if we've hit another section header (starts with '[')
+			if strings.HasPrefix(trimmed, "[") {
+				// End of plugin section
+				plugins = append(plugins, strings.Join(currentPlugin, "\n"))
+				currentPlugin = nil
+				inPlugin = false
+				continue
+			}
+			// Add line to current plugin
+			currentPlugin = append(currentPlugin, line)
+		}
+	}
+
+	// Don't forget the last plugin if we ended in one
+	if inPlugin && len(currentPlugin) > 0 {
+		plugins = append(plugins, strings.Join(currentPlugin, "\n"))
+	}
+
+	return plugins
+}
+
+// removePluginsSections removes all [[plugins]] sections from TOML
+// Used to strip default plugins from v1.2 template before merging saved v1.1 plugins
+func removePluginsSections(toml string) string {
+	var result []string
+	lines := strings.Split(toml, "\n")
+	inPlugin := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check if this is the start of a [[plugins]] section
+		if trimmed == "[[plugins]]" {
+			inPlugin = true
+			continue
+		}
+
+		// If we're in a plugin section
+		if inPlugin {
+			// Check if we've hit another section header (starts with '[')
+			if strings.HasPrefix(trimmed, "[") {
+				// End of plugin section, include this new section header
+				inPlugin = false
+				result = append(result, line)
+				continue
+			}
+			// Skip lines inside plugin section
+			continue
+		}
+
+		// Not in plugin section, keep the line
+		result = append(result, line)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// mergePluginsFromBackup merges [[plugins]] sections from backup ConfigMap into recreated v1.2 KBS config
+func (r *KbsConfigReconciler) mergePluginsFromBackup(ctx context.Context, configMap *corev1.ConfigMap, backupConfigMap *corev1.ConfigMap) error {
+	// Extract plugins from backup
+	backupToml, hasToml := backupConfigMap.Data["kbs-config.toml"]
+	if !hasToml {
+		r.log.Info("Backup ConfigMap has no kbs-config.toml, adding migration annotation")
+		// Clean up backup
+		if err := r.Delete(ctx, backupConfigMap); err != nil {
+			r.log.Info("Failed to delete backup ConfigMap", "name", backupConfigMap.Name, "err", err)
+		}
+		return r.addMigrationAnnotation(ctx, configMap)
+	}
+
+	// Extract [[plugins]] sections from backup
+	pluginsSections := extractPluginsSections(backupToml)
+
+	if len(pluginsSections) == 0 {
+		r.log.Info("No plugins in backup to merge, adding migration annotation")
+		// Clean up backup
+		if err := r.Delete(ctx, backupConfigMap); err != nil {
+			r.log.Info("Failed to delete backup ConfigMap", "name", backupConfigMap.Name, "err", err)
+		}
+		return r.addMigrationAnnotation(ctx, configMap)
+	}
+
+	// Get current TOML from recreated ConfigMap
+	tomlData, hasToml := configMap.Data["kbs-config.toml"]
+	if !hasToml {
+		return fmt.Errorf("recreated ConfigMap has no kbs-config.toml")
+	}
+
+	// Remove any existing [[plugins]] sections from the v1.2 template
+	// to avoid duplicates when we append the saved v1.1 plugins
+	tomlWithoutPlugins := removePluginsSections(tomlData)
+
+	// Transform plugins from v1.1 to v1.2 format and append
+	transformedPlugins := transformPluginsToV12(pluginsSections)
+	mergedToml := tomlWithoutPlugins + "\n\n" + strings.Join(transformedPlugins, "\n\n")
+
+	// Update ConfigMap
+	configMap.Data["kbs-config.toml"] = mergedToml
+
+	// Add migration annotation
+	if configMap.Annotations == nil {
+		configMap.Annotations = make(map[string]string)
+	}
+	configMap.Annotations[MigrationAnnotation] = MigrationVersion
+
+	err := r.Update(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to update ConfigMap with merged plugins: %w", err)
+	}
+
+	r.log.Info("Successfully merged plugins into v1.2 KBS config", "count", len(pluginsSections))
+	r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "ConfigMapMigrated",
+		"ConfigMapMigrated", "Merged %d plugin(s) from backup %s into v1.2 KBS config ConfigMap %s (backup preserved)", len(pluginsSections), backupConfigMap.Name, configMap.Name)
+
+	return nil
+}
+
+// transformPluginsToV12 transforms [[plugins]] sections from v1.1 to v1.2 format
+// v1.1: type = "LocalFs" | "Vault"
+// v1.2: storage_backend_type = "kvstorage" | "Vault"
+func transformPluginsToV12(pluginsSections []string) []string {
+	var transformed []string
+
+	for _, plugin := range pluginsSections {
+		// For resource plugin with LocalFs, transform to storage_backend_type = "kvstorage"
+		if strings.Contains(plugin, `name = "resource"`) && strings.Contains(plugin, `type = "LocalFs"`) {
+			// Replace type = "LocalFs" with storage_backend_type = "kvstorage"
+			plugin = strings.ReplaceAll(plugin, `type = "LocalFs"`, `storage_backend_type = "kvstorage"`)
+			// Remove dir_path if present (v1.2 uses storage_backend configuration)
+			lines := strings.Split(plugin, "\n")
+			var filtered []string
+			for _, line := range lines {
+				if !strings.Contains(line, "dir_path =") {
+					filtered = append(filtered, line)
+				}
+			}
+			plugin = strings.Join(filtered, "\n")
+		} else if strings.Contains(plugin, `name = "resource"`) && strings.Contains(plugin, `type = "Vault"`) {
+			// For Vault, just rename the field from type to storage_backend_type
+			plugin = strings.ReplaceAll(plugin, `type = "Vault"`, `storage_backend_type = "Vault"`)
+		}
+		// Append the transformed plugin
+		transformed = append(transformed, plugin)
+	}
+
+	return transformed
+}
+
+// migrateRvpsConfigMap migrates RVPS reference values from old format to new format
+// Old format: reference-values.json with array structure (plain JSON)
+// Example: [{"name": "svn", "expiration": "2027-01-01T00:00:00Z", "value": 1}]
+//
+// New format: reference_value with object structure (base64-encoded JSON values)
+// Example: {"svn": "eyJleHBpcmF0aW9uIjoiMjAyNy0wMS0wMVQwMDowMDowMFoiLCJ2YWx1ZSI6MX0="}
+func (r *KbsConfigReconciler) migrateRvpsConfigMap(ctx context.Context) error {
+	configMap := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{
+		Namespace: r.namespace,
+		Name:      r.kbsConfig.Spec.KbsRvpsRefValuesConfigMapName,
+	}, configMap)
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.log.V(1).Info("RVPS ConfigMap not found, skipping migration")
+			return nil
+		}
+		return err
+	}
+
+	// Check if already migrated
+	if configMap.Annotations != nil {
+		if _, exists := configMap.Annotations[MigrationAnnotation]; exists {
+			r.log.V(1).Info("RVPS ConfigMap already migrated", "name", configMap.Name)
+			return nil
+		}
+	}
+
+	// Get the old format data
+	oldData, hasOldFormat := configMap.Data["reference-values.json"]
+
+	if !hasOldFormat {
+		// No old format found, just add migration annotation
+		r.log.V(1).Info("RVPS ConfigMap has no old format data, adding migration annotation", "name", configMap.Name)
+		return r.addMigrationAnnotation(ctx, configMap)
+	}
+
+	r.log.Info("Migrating RVPS ConfigMap from old format to new format", "name", configMap.Name)
+
+	// Create backup before modifying
+	err = r.createConfigMapBackup(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to create backup of RVPS ConfigMap: %w", err)
+	}
+
+	// Parse old format (array of objects)
+	var oldFormat []map[string]any
+	err = json.Unmarshal([]byte(oldData), &oldFormat)
+	if err != nil {
+		r.log.Info("Failed to parse old RVPS format, skipping migration", "err", err)
+		return nil // Don't fail reconciliation on parse errors
+	}
+
+	// Convert to new format (object with base64-encoded values)
+	newFormat := make(map[string]string)
+	for _, item := range oldFormat {
+		name, hasName := item["name"].(string)
+		if !hasName {
+			r.log.Info("Skipping RVPS entry without name field", "item", item)
+			continue
+		}
+
+		// Keep the entire item including the "name" field in the base64-encoded value
+		// The name field is used as the key in the new format AND kept in the value
+
+		// Marshal the complete item to compact JSON (no whitespace)
+		valueJSON, err := json.Marshal(item)
+		if err != nil {
+			r.log.Info("Failed to marshal RVPS entry, skipping", "name", name, "err", err)
+			continue
+		}
+
+		// Base64 encode the compact JSON
+		encodedValue := base64Encode(valueJSON)
+		newFormat[name] = encodedValue
+	}
+
+	// Marshal new format to JSON
+	newDataBytes, err := json.MarshalIndent(newFormat, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal new RVPS format: %w", err)
+	}
+
+	// Update ConfigMap with new format
+	configMap.Data["reference_value"] = string(newDataBytes)
+	// Remove old format - migration to v1.2 is complete
+	delete(configMap.Data, "reference-values.json")
+
+	// Add migration annotation
+	if configMap.Annotations == nil {
+		configMap.Annotations = make(map[string]string)
+	}
+	configMap.Annotations[MigrationAnnotation] = MigrationVersion
+
+	err = r.Update(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to update migrated RVPS ConfigMap: %w", err)
+	}
+
+	r.log.Info("Successfully migrated RVPS ConfigMap", "name", configMap.Name)
+	r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "ConfigMapMigrated",
+		"ConfigMapMigrated", "Migrated RVPS ConfigMap %s from v1.1.0 format to v1.2.0 format", configMap.Name)
+
+	return nil
+}
+
+// migrateResourcePolicyConfigMap migrates resource policy ConfigMap
+// If the ConfigMap exists but doesn't have the migration annotation,
+// delete it so the reconciliation loop recreates it with updated content.
+// This ensures the policy content matches the current profile and settings.
+func (r *KbsConfigReconciler) migrateResourcePolicyConfigMap(ctx context.Context) error {
+	return r.migrateGeneratedPolicyConfigMap(ctx,
+		r.kbsConfig.Spec.KbsResourcePolicyConfigMapName,
+		"resource policy")
+}
+
+// migrateAttestationPolicyConfigMap migrates CPU attestation policy ConfigMap
+// If the ConfigMap exists but doesn't have the migration annotation,
+// delete it so the reconciliation loop recreates it with updated content.
+func (r *KbsConfigReconciler) migrateAttestationPolicyConfigMap(ctx context.Context) error {
+	return r.migrateGeneratedPolicyConfigMap(ctx,
+		r.kbsConfig.Spec.KbsAttestationPolicyConfigMapName,
+		"CPU attestation policy")
+}
+
+// migrateGpuAttestationPolicyConfigMap migrates GPU attestation policy ConfigMap
+// If the ConfigMap exists but doesn't have the migration annotation,
+// delete it so the reconciliation loop recreates it with updated content.
+func (r *KbsConfigReconciler) migrateGpuAttestationPolicyConfigMap(ctx context.Context) error {
+	return r.migrateGeneratedPolicyConfigMap(ctx,
+		r.kbsConfig.Spec.KbsGpuAttestationPolicyConfigMapName,
+		"GPU attestation policy")
+}
+
+// migrateGeneratedPolicyConfigMap handles migration of dynamically generated policy ConfigMaps
+// These ConfigMaps are generated based on the profile and other settings, so if they exist
+// without a migration annotation, we create a backup and delete them, letting the reconciliation
+// loop recreate them with updated content.
+func (r *KbsConfigReconciler) migrateGeneratedPolicyConfigMap(ctx context.Context, configMapName, description string) error {
+	if configMapName == "" {
+		return nil
+	}
+
+	configMap := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{
+		Namespace: r.namespace,
+		Name:      configMapName,
+	}, configMap)
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			r.log.V(1).Info("ConfigMap not found, skipping migration", "name", configMapName, "type", description)
+			return nil
+		}
+		return err
+	}
+
+	// Check if already migrated
+	if configMap.Annotations != nil {
+		if _, exists := configMap.Annotations[MigrationAnnotation]; exists {
+			r.log.V(1).Info("ConfigMap already migrated", "name", configMap.Name, "type", description)
+			return nil
+		}
+	}
+
+	// ConfigMap exists but has no migration annotation - create backup and delete it
+	// The reconciliation loop will recreate it with updated content
+	r.log.Info("Creating backup and deleting policy ConfigMap to trigger recreation", "name", configMap.Name, "type", description)
+
+	// Create backup before deletion
+	err = r.createConfigMapBackup(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to create backup of %s ConfigMap: %w", description, err)
+	}
+
+	err = r.Delete(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to delete %s ConfigMap for migration: %w", description, err)
+	}
+
+	r.log.Info("Successfully deleted non-migrated ConfigMap", "name", configMap.Name, "type", description)
+	r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "ConfigMapDeleted",
+		"ConfigMapMigration", "Deleted %s ConfigMap %s for migration - will be recreated with updated content (backup: %s)", description, configMap.Name, configMap.Name+BackupSuffix)
+
+	return nil
+}
+
+// addMigrationAnnotation adds the migration annotation to a ConfigMap that's already in the new format
+func (r *KbsConfigReconciler) addMigrationAnnotation(ctx context.Context, configMap *corev1.ConfigMap) error {
+	if configMap.Annotations == nil {
+		configMap.Annotations = make(map[string]string)
+	}
+
+	// Check if already annotated
+	if _, exists := configMap.Annotations[MigrationAnnotation]; exists {
+		return nil
+	}
+
+	configMap.Annotations[MigrationAnnotation] = MigrationVersion
+	err := r.Update(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to add migration annotation to ConfigMap %s: %w", configMap.Name, err)
+	}
+
+	return nil
+}
+
+// base64Encode encodes data to base64 string (standard encoding, no line wrapping)
+func base64Encode(data []byte) string {
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+// createConfigMapBackup creates a backup copy of a ConfigMap with .v1.1 suffix
+// The backup is preserved after migration for safety and manual recovery if needed
+func (r *KbsConfigReconciler) createConfigMapBackup(ctx context.Context, configMap *corev1.ConfigMap) error {
+	backupName := configMap.Name + BackupSuffix
+
+	// Check if backup already exists
+	existingBackup := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{
+		Namespace: configMap.Namespace,
+		Name:      backupName,
+	}, existingBackup)
+
+	if err == nil {
+		r.log.Info("Backup ConfigMap already exists, skipping creation", "name", backupName)
+		return nil
+	}
+
+	if !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check for existing backup: %w", err)
+	}
+
+	// Create backup ConfigMap
+	backup := &corev1.ConfigMap{
+		ObjectMeta: configMap.ObjectMeta,
+		Data:       configMap.Data,
+		BinaryData: configMap.BinaryData,
+	}
+	backup.Name = backupName
+	backup.ResourceVersion = ""
+	backup.UID = ""
+	backup.CreationTimestamp = configMap.CreationTimestamp
+
+	if backup.Annotations == nil {
+		backup.Annotations = make(map[string]string)
+	}
+	backup.Annotations["kbs.confidentialcontainers.org/backup-of"] = configMap.Name
+	backup.Annotations["kbs.confidentialcontainers.org/backup-timestamp"] = configMap.CreationTimestamp.String()
+
+	err = r.Create(ctx, backup)
+	if err != nil {
+		return fmt.Errorf("failed to create backup ConfigMap: %w", err)
+	}
+
+	r.log.Info("Created backup ConfigMap (will be preserved)", "name", backupName, "original", configMap.Name)
+	r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "ConfigMapBackupCreated",
+		"ConfigMapMigration", "Created backup %s of ConfigMap %s before migration (preserved for safety)", backupName, configMap.Name)
+
+	return nil
+}

--- a/internal/controller/migration_test.go
+++ b/internal/controller/migration_test.go
@@ -1,0 +1,548 @@
+/*
+Copyright Confidential Containers Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/trustee-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMigrateRvpsConfigMap(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputData      map[string]string
+		expectMigrated bool
+		expectError    bool
+	}{
+		{
+			name: "Old format with reference-values.json",
+			inputData: map[string]string{
+				"reference-values.json": `[
+					{
+						"name": "svn",
+						"expiration": "2026-01-01T00:00:00Z",
+						"value": 1
+					}
+				]`,
+			},
+			expectMigrated: true,
+			expectError:    false,
+		},
+		{
+			name: "New format only",
+			inputData: map[string]string{
+				"reference_value": `{"svn": {"value": 1}}`,
+			},
+			expectMigrated: true,
+			expectError:    false,
+		},
+		{
+			name:           "Empty ConfigMap",
+			inputData:      map[string]string{},
+			expectMigrated: false, // Empty ConfigMap doesn't get migrated
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with the test ConfigMap
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rvps-configmap",
+					Namespace: "default",
+				},
+				Data: tt.inputData,
+			}
+
+			kbsConfig := &confidentialcontainersorgv1alpha1.KbsConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kbsconfig",
+					Namespace: "default",
+				},
+				Spec: confidentialcontainersorgv1alpha1.KbsConfigSpec{
+					KbsRvpsRefValuesConfigMapName: "test-rvps-configmap",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(configMap, kbsConfig).
+				Build()
+
+			// Create reconciler
+			r := &KbsConfigReconciler{
+				Client:    fakeClient,
+				Scheme:    scheme,
+				Recorder:  &events.FakeRecorder{},
+				kbsConfig: kbsConfig,
+				log:       logr.Discard(),
+				namespace: "default",
+			}
+
+			// Run migration
+			err := r.migrateRvpsConfigMap(context.Background())
+
+			// Check error
+			if (err != nil) != tt.expectError {
+				t.Errorf("migrateRvpsConfigMap() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+
+			// Verify migration annotation was added
+			updatedConfigMap := &corev1.ConfigMap{}
+			err = fakeClient.Get(context.Background(),
+				types.NamespacedName{Name: "test-rvps-configmap", Namespace: "default"},
+				updatedConfigMap)
+			if err != nil {
+				t.Fatalf("Failed to get updated ConfigMap: %v", err)
+			}
+
+			if tt.expectMigrated {
+				if updatedConfigMap.Annotations[MigrationAnnotation] != MigrationVersion {
+					t.Errorf("Expected migration annotation, got %v", updatedConfigMap.Annotations)
+				}
+
+				// If old format existed, verify new format was created with base64 encoding
+				if _, hasOld := tt.inputData["reference-values.json"]; hasOld {
+					newValue, hasNew := updatedConfigMap.Data["reference_value"]
+					if !hasNew {
+						t.Errorf("Expected new format key 'reference_value' to be created")
+					}
+
+					// Verify the new format is base64-encoded
+					// Parse the new format JSON
+					var newFormat map[string]string
+					err := json.Unmarshal([]byte(newValue), &newFormat)
+					if err != nil {
+						t.Errorf("Failed to parse new format JSON: %v", err)
+					}
+
+					// Verify "svn" key exists and is base64-encoded
+					if encodedValue, ok := newFormat["svn"]; ok {
+						// Try to decode it - should be valid base64
+						decodedBytes, err := base64.StdEncoding.DecodeString(encodedValue)
+						if err != nil {
+							t.Errorf("Expected base64-encoded value, got error decoding: %v", err)
+						}
+
+						// Decoded value should be valid JSON
+						var decodedJSON map[string]any
+						err = json.Unmarshal(decodedBytes, &decodedJSON)
+						if err != nil {
+							t.Errorf("Expected decoded base64 to be valid JSON, got error: %v", err)
+						}
+
+						// Verify fields exist in decoded JSON (WITH "name" field)
+						if _, hasName := decodedJSON["name"]; !hasName {
+							t.Errorf("Expected 'name' field to be present in value, but it's missing")
+						}
+						if _, hasValue := decodedJSON["value"]; !hasValue {
+							t.Errorf("Expected 'value' field to exist in decoded JSON")
+						}
+						// Verify the name field matches the key
+						if decodedJSON["name"] != "svn" {
+							t.Errorf("Expected 'name' field to be %q, got %q", "svn", decodedJSON["name"])
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMigrateKbsConfigMap(t *testing.T) {
+	oldKbsConfigToml := `[http_server]
+sockets = ["0.0.0.0:8080"]
+insecure_http = false
+private_key = "/etc/https-key/privateKey"
+certificate = "/etc/https-cert/certificate"
+worker_count = 4
+
+[admin]
+type = "DenyAll"
+insecure_api = false
+auth_public_key = "/etc/auth-secret/publicKey"
+
+[attestation_token]
+insecure_key = false
+attestation_token_type = "CoCo"
+trusted_certs_paths = ["/etc/attestation-cert/token.crt"]
+
+[attestation_service]
+type = "coco_as_builtin"
+work_dir = "/opt/confidential-containers/attestation-service"
+policy_engine = "opa"
+
+[attestation_service.attestation_token_broker]
+type = "Ear"
+policy_dir = "/opt/confidential-containers/attestation-service/policies"
+
+[attestation_service.attestation_token_config]
+duration_min = 5
+
+[attestation_service.rvps_config]
+type = "BuiltIn"
+
+[attestation_service.verifier_config.snp_verifier]
+# Configure VCEK sources to try, in order. Defaults to [KDS].
+vcek_sources = [
+    { type = "OfflineStore" },
+    { type = "KDS" }
+]
+
+[attestation_service.rvps_config.storage]
+type = "LocalJson"
+file_path = "/opt/confidential-containers/rvps/reference-values/reference-values.json"
+
+[attestation_service.verifier_config.nvidia_verifier]
+type = "Remote"
+verifier_url = "https://nras.attestation.nvidia.com/v4/attest"
+
+[attestation_service.attestation_token_broker.signer]
+key_path = "/etc/attestation-key/token.key"
+cert_path = "/etc/attestation-cert/token.crt"
+
+[[plugins]]
+name = "resource"
+type = "LocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"
+
+[policy_engine]
+policy_path = "/opt/confidential-containers/opa/policy.rego"`
+
+	tests := []struct {
+		name             string
+		inputData        map[string]string
+		inputAnnotations map[string]string
+		expectDeleted    bool
+		expectPreserved  bool
+	}{
+		{
+			name: "Old format KBS config with v1.1.0 paths - should delete and save plugins",
+			inputData: map[string]string{
+				"kbs-config.toml": oldKbsConfigToml,
+			},
+			inputAnnotations: nil,
+			expectDeleted:    true,
+			expectPreserved:  false,
+		},
+		{
+			name: "Already migrated KBS config - should preserve",
+			inputData: map[string]string{
+				"kbs-config.toml": `dir_path = "/opt/confidential-containers/storage/repository"`,
+			},
+			inputAnnotations: map[string]string{
+				MigrationAnnotation: MigrationVersion,
+			},
+			expectDeleted:   false,
+			expectPreserved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with the test ConfigMap
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-kbs-config",
+					Namespace:   "default",
+					Annotations: tt.inputAnnotations,
+				},
+				Data: tt.inputData,
+			}
+
+			kbsConfig := &confidentialcontainersorgv1alpha1.KbsConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kbsconfig",
+					Namespace: "default",
+				},
+				Spec: confidentialcontainersorgv1alpha1.KbsConfigSpec{
+					KbsConfigMapName: "test-kbs-config",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(configMap, kbsConfig).
+				Build()
+
+			// Create reconciler
+			r := &KbsConfigReconciler{
+				Client:    fakeClient,
+				Scheme:    scheme,
+				Recorder:  &events.FakeRecorder{},
+				kbsConfig: kbsConfig,
+				log:       logr.Discard(),
+				namespace: "default",
+			}
+
+			// Run migration
+			err := r.migrateKbsConfigMap(context.Background())
+			if err != nil {
+				t.Fatalf("migrateKbsConfigMap() error = %v", err)
+			}
+
+			// Verify migration behavior
+			updatedConfigMap := &corev1.ConfigMap{}
+			err = fakeClient.Get(context.Background(),
+				types.NamespacedName{Name: "test-kbs-config", Namespace: "default"},
+				updatedConfigMap)
+
+			if tt.expectDeleted {
+				// ConfigMap without migration annotation should be deleted
+				if !k8serrors.IsNotFound(err) {
+					t.Errorf("Expected ConfigMap to be deleted for migration, but it still exists")
+				}
+
+				// Verify backup ConfigMap was created
+				backupConfigMap := &corev1.ConfigMap{}
+				backupName := "test-kbs-config" + BackupSuffix
+				err = fakeClient.Get(context.Background(),
+					types.NamespacedName{Name: backupName, Namespace: "default"},
+					backupConfigMap)
+				if err != nil {
+					t.Fatalf("Expected backup ConfigMap %s to exist, got error: %v", backupName, err)
+				}
+
+				// Verify backup has the original data
+				if _, hasToml := backupConfigMap.Data["kbs-config.toml"]; !hasToml {
+					t.Errorf("Expected backup ConfigMap to have kbs-config.toml")
+				}
+
+				// Verify backup has metadata annotations
+				if backupOf, ok := backupConfigMap.Annotations["kbs.confidentialcontainers.org/backup-of"]; !ok || backupOf != "test-kbs-config" {
+					t.Errorf("Expected backup ConfigMap to have backup-of annotation pointing to original")
+				}
+			}
+
+			if tt.expectPreserved {
+				// ConfigMap with migration annotation should be preserved
+				if err != nil {
+					t.Fatalf("Failed to get ConfigMap: %v", err)
+				}
+				if updatedConfigMap.Annotations[MigrationAnnotation] != MigrationVersion {
+					t.Errorf("Expected migration annotation to be preserved, got %v", updatedConfigMap.Annotations)
+				}
+			}
+		})
+	}
+}
+
+func TestTransformPluginsToV12(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name: "LocalFs transforms to kvstorage",
+			input: []string{`[[plugins]]
+name = "resource"
+type = "LocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"`},
+			expected: []string{`[[plugins]]
+name = "resource"
+storage_backend_type = "kvstorage"`},
+		},
+		{
+			name: "Vault transforms type to storage_backend_type",
+			input: []string{`[[plugins]]
+name = "resource"
+type = "Vault"
+vault_address = "https://vault.example.com:8200"
+vault_token = "s.mytoken123"
+vault_path = "secret/data/kbs"`},
+			expected: []string{`[[plugins]]
+name = "resource"
+storage_backend_type = "Vault"
+vault_address = "https://vault.example.com:8200"
+vault_token = "s.mytoken123"
+vault_path = "secret/data/kbs"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := transformPluginsToV12(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d plugins, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("Plugin %d mismatch.\nExpected:\n%s\n\nGot:\n%s", i, tt.expected[i], result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRemovePluginsSections(t *testing.T) {
+	input := `[http_server]
+sockets = ["0.0.0.0:8080"]
+
+[[plugins]]
+name = "resource"
+storage_backend_type = "kvstorage"
+
+[policy_engine]
+policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"`
+
+	expected := `[http_server]
+sockets = ["0.0.0.0:8080"]
+
+[policy_engine]
+policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"`
+
+	result := removePluginsSections(input)
+	if result != expected {
+		t.Errorf("removePluginsSections failed.\nExpected:\n%s\n\nGot:\n%s", expected, result)
+	}
+}
+
+func TestMigrateResourcePolicyConfigMap(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputData        map[string]string
+		inputAnnotations map[string]string
+		expectDeleted    bool
+		expectPreserved  bool
+	}{
+		{
+			name: "Old format without migration annotation - should delete",
+			inputData: map[string]string{
+				"policy.rego": "package policy\ndefault allow = false",
+			},
+			inputAnnotations: nil,
+			expectDeleted:    true,
+			expectPreserved:  false,
+		},
+		{
+			name: "New format without migration annotation - should delete",
+			inputData: map[string]string{
+				"resource-policy.rego": "package policy\ndefault allow = false",
+			},
+			inputAnnotations: nil,
+			expectDeleted:    true,
+			expectPreserved:  false,
+		},
+		{
+			name: "Already migrated - should preserve",
+			inputData: map[string]string{
+				"resource-policy.rego": "package policy\ndefault allow = false",
+			},
+			inputAnnotations: map[string]string{
+				MigrationAnnotation: MigrationVersion,
+			},
+			expectDeleted:   false,
+			expectPreserved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with the test ConfigMap
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-resource-policy",
+					Namespace:   "default",
+					Annotations: tt.inputAnnotations,
+				},
+				Data: tt.inputData,
+			}
+
+			kbsConfig := &confidentialcontainersorgv1alpha1.KbsConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kbsconfig",
+					Namespace: "default",
+				},
+				Spec: confidentialcontainersorgv1alpha1.KbsConfigSpec{
+					KbsResourcePolicyConfigMapName: "test-resource-policy",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(configMap, kbsConfig).
+				Build()
+
+			// Create reconciler
+			r := &KbsConfigReconciler{
+				Client:    fakeClient,
+				Scheme:    scheme,
+				Recorder:  &events.FakeRecorder{},
+				kbsConfig: kbsConfig,
+				log:       logr.Discard(),
+				namespace: "default",
+			}
+
+			// Run migration
+			err := r.migrateResourcePolicyConfigMap(context.Background())
+			if err != nil {
+				t.Fatalf("migrateResourcePolicyConfigMap() error = %v", err)
+			}
+
+			// Verify migration behavior
+			updatedConfigMap := &corev1.ConfigMap{}
+			err = fakeClient.Get(context.Background(),
+				types.NamespacedName{Name: "test-resource-policy", Namespace: "default"},
+				updatedConfigMap)
+
+			if tt.expectDeleted {
+				// ConfigMap without migration annotation should be deleted
+				if !k8serrors.IsNotFound(err) {
+					t.Errorf("Expected ConfigMap to be deleted for migration, but it still exists")
+				}
+			}
+
+			if tt.expectPreserved {
+				// ConfigMap with migration annotation should be preserved
+				if err != nil {
+					t.Fatalf("Failed to get ConfigMap: %v", err)
+				}
+				if updatedConfigMap.Annotations[MigrationAnnotation] != MigrationVersion {
+					t.Errorf("Expected migration annotation to be preserved, got %v", updatedConfigMap.Annotations)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/trusteeconfig_controller.go
+++ b/internal/controller/trusteeconfig_controller.go
@@ -343,9 +343,24 @@ func (r *TrusteeConfigReconciler) mergeKbsConfigSpecs(generatedSpec, manualSpec 
 		}
 	}
 
-	// Preserve manual secret resources
-	if len(manualSpec.KbsSecretResources) > 0 {
-		merged.KbsSecretResources = manualSpec.KbsSecretResources
+	// Merge secret resources: preserve manual ones and add any new generated ones
+	// Use a map to track unique secret names
+	secretResourcesMap := make(map[string]bool)
+
+	// First, add all manual secret resources
+	for _, secret := range manualSpec.KbsSecretResources {
+		secretResourcesMap[secret] = true
+	}
+
+	// Then, add any generated secret resources that aren't already present
+	for _, secret := range generatedSpec.KbsSecretResources {
+		secretResourcesMap[secret] = true
+	}
+
+	// Convert map back to slice
+	merged.KbsSecretResources = make([]string, 0, len(secretResourcesMap))
+	for secret := range secretResourcesMap {
+		merged.KbsSecretResources = append(merged.KbsSecretResources, secret)
 	}
 
 	// Preserve manual local cert cache configuration
@@ -648,14 +663,21 @@ func (r *TrusteeConfigReconciler) createOrUpdateKbsConfigMap(ctx context.Context
 		return err
 	}
 
-	// ConfigMap exists - generate new config with current TLS settings
+	// ConfigMap exists - merge TLS settings only
+	// The actual v1.1 -> v1.2 content migration is handled by KbsConfig controller
+	// in migration.go using string replacement to preserve user customizations
+	r.log.V(1).Info("Merging TLS settings into existing KBS config", "ConfigMap.Namespace", r.namespace, "ConfigMap.Name", configMapName)
+
+	// Get existing config data for TLS merge
+	existingConfig := found.Data["kbs-config.toml"]
+
+	// Generate fresh config to extract TLS settings
 	newConfigMap, err := r.generateKbsConfigMap(ctx)
 	if err != nil {
 		return err
 	}
 
 	newConfig := newConfigMap.Data["kbs-config.toml"]
-	existingConfig := found.Data["kbs-config.toml"]
 
 	// Merge TLS settings from new config into existing config
 	mergedConfig := mergeTlsSettings(existingConfig, newConfig)
@@ -1153,6 +1175,9 @@ func (r *TrusteeConfigReconciler) generateResourcePolicyConfigMap(ctx context.Co
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getResourcePolicyConfigMapName(),
 			Namespace: r.namespace,
+			Annotations: map[string]string{
+				MigrationAnnotation: MigrationVersion,
+			},
 		},
 		Data: map[string]string{
 			resourcePolicyFilename: policyRego,
@@ -1257,6 +1282,9 @@ func (r *TrusteeConfigReconciler) generateAttestationPolicyConfigMap(ctx context
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getCpuAttestationPolicyConfigMapName(),
 			Namespace: r.namespace,
+			Annotations: map[string]string{
+				MigrationAnnotation: MigrationVersion,
+			},
 		},
 		Data: map[string]string{
 			"default_cpu.rego": policyRego,
@@ -1282,6 +1310,9 @@ func (r *TrusteeConfigReconciler) generateGpuAttestationPolicyConfigMap(ctx cont
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getGpuAttestationPolicyConfigMapName(),
 			Namespace: r.namespace,
+			Annotations: map[string]string{
+				MigrationAnnotation: MigrationVersion,
+			},
 		},
 		Data: map[string]string{
 			"default_gpu.rego": policyRegoGPU,

--- a/internal/controller/trusteeconfig_merge_test.go
+++ b/internal/controller/trusteeconfig_merge_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright Confidential Containers Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/trustee-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMergeKbsConfigSpecs_SecretResources(t *testing.T) {
+	tests := []struct {
+		name                     string
+		generatedSecretResources []string
+		manualSecretResources    []string
+		expectedSecretResources  []string
+		description              string
+	}{
+		{
+			name:                     "Merge operator-generated and manual secrets",
+			generatedSecretResources: []string{"attestation-status"},
+			manualSecretResources:    []string{"my-custom-secret"},
+			expectedSecretResources:  []string{"attestation-status", "my-custom-secret"},
+			description:              "Should contain both operator-generated attestation-status and manual secret",
+		},
+		{
+			name:                     "Preserve operator-generated secret when empty manual",
+			generatedSecretResources: []string{"attestation-status"},
+			manualSecretResources:    []string{},
+			expectedSecretResources:  []string{"attestation-status"},
+			description:              "Should preserve operator-generated secret when no manual secrets",
+		},
+		{
+			name:                     "Preserve manual secrets when empty generated",
+			generatedSecretResources: []string{},
+			manualSecretResources:    []string{"my-custom-secret"},
+			expectedSecretResources:  []string{"my-custom-secret"},
+			description:              "Should preserve manual secrets when no generated secrets",
+		},
+		{
+			name:                     "Deduplicate when same secret in both",
+			generatedSecretResources: []string{"attestation-status", "shared-secret"},
+			manualSecretResources:    []string{"shared-secret", "my-custom-secret"},
+			expectedSecretResources:  []string{"attestation-status", "shared-secret", "my-custom-secret"},
+			description:              "Should deduplicate when same secret appears in both lists",
+		},
+		{
+			name:                     "Handle multiple operator-generated secrets",
+			generatedSecretResources: []string{"attestation-status", "another-operator-secret"},
+			manualSecretResources:    []string{"my-custom-secret"},
+			expectedSecretResources:  []string{"attestation-status", "another-operator-secret", "my-custom-secret"},
+			description:              "Should merge all secrets from both lists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client for the reconciler
+			scheme := runtime.NewScheme()
+			_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+
+			// Create reconciler
+			r := &TrusteeConfigReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+				log:    logr.Discard(),
+			}
+
+			// Create generated and manual specs
+			generatedSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+				KbsSecretResources: tt.generatedSecretResources,
+			}
+
+			manualSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+				KbsSecretResources: tt.manualSecretResources,
+			}
+
+			// Run merge
+			merged := r.mergeKbsConfigSpecs(generatedSpec, manualSpec)
+
+			// Verify that all expected secrets are present
+			mergedMap := make(map[string]bool)
+			for _, secret := range merged.KbsSecretResources {
+				mergedMap[secret] = true
+			}
+
+			for _, expectedSecret := range tt.expectedSecretResources {
+				if !mergedMap[expectedSecret] {
+					t.Errorf("%s: expected secret %q not found in merged list. Got: %v",
+						tt.description, expectedSecret, merged.KbsSecretResources)
+				}
+			}
+
+			// Verify no unexpected secrets
+			if len(merged.KbsSecretResources) != len(tt.expectedSecretResources) {
+				t.Errorf("%s: expected %d secrets, got %d. Expected: %v, Got: %v",
+					tt.description,
+					len(tt.expectedSecretResources),
+					len(merged.KbsSecretResources),
+					tt.expectedSecretResources,
+					merged.KbsSecretResources)
+			}
+		})
+	}
+}
+
+func TestMergeKbsConfigSpecs_UpgradeMigrationScenario(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	r := &TrusteeConfigReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		log:    logr.Discard(),
+	}
+
+	// Simulate upgrade from v1.1 to v1.2:
+	// - v1.1 KbsConfig had user's custom secrets
+	// - v1.2 TrusteeConfig generates spec with attestation-status
+	// - After merge, both should be present
+
+	// This is what TrusteeConfig generates in v1.2 (new format with attestation-status)
+	generatedSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+		KbsSecretResources: []string{"attestation-status"},
+	}
+
+	// This is what was in the existing v1.1 KbsConfig (user's custom secrets)
+	manualSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+		KbsSecretResources: []string{"user-secret-1", "user-secret-2"},
+	}
+
+	// Run merge
+	merged := r.mergeKbsConfigSpecs(generatedSpec, manualSpec)
+
+	// Verify all secrets are present
+	expectedSecrets := []string{"attestation-status", "user-secret-1", "user-secret-2"}
+	mergedMap := make(map[string]bool)
+	for _, secret := range merged.KbsSecretResources {
+		mergedMap[secret] = true
+	}
+
+	for _, expectedSecret := range expectedSecrets {
+		if !mergedMap[expectedSecret] {
+			t.Errorf("Upgrade scenario failed: expected secret %q not found in merged list. Got: %v",
+				expectedSecret, merged.KbsSecretResources)
+		}
+	}
+
+	if len(merged.KbsSecretResources) != len(expectedSecrets) {
+		t.Errorf("Upgrade scenario failed: expected %d secrets, got %d. Expected: %v, Got: %v",
+			len(expectedSecrets),
+			len(merged.KbsSecretResources),
+			expectedSecrets,
+			merged.KbsSecretResources)
+	}
+}
+
+func TestMergeKbsConfigSpecs_RestrictedProfileMigration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	r := &TrusteeConfigReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		log:    logr.Discard(),
+	}
+
+	// Exact scenario from the cluster:
+	// - Generated spec (from Restricted profile): ["attestation-status"]
+	// - Manual spec (from v1.1 KbsConfig): ["kbsres1", "security-policy"]
+	// - Expected after merge: all three secrets
+
+	generatedSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+		KbsSecretResources: []string{"attestation-status"},
+	}
+
+	manualSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+		KbsSecretResources: []string{"kbsres1", "security-policy"},
+	}
+
+	merged := r.mergeKbsConfigSpecs(generatedSpec, manualSpec)
+
+	// Verify all three secrets are present
+	expectedSecrets := []string{"attestation-status", "kbsres1", "security-policy"}
+	mergedMap := make(map[string]bool)
+	for _, secret := range merged.KbsSecretResources {
+		mergedMap[secret] = true
+	}
+
+	for _, expectedSecret := range expectedSecrets {
+		if !mergedMap[expectedSecret] {
+			t.Errorf("Restricted profile migration failed: expected secret %q not found. Got: %v",
+				expectedSecret, merged.KbsSecretResources)
+		}
+	}
+
+	if len(merged.KbsSecretResources) != len(expectedSecrets) {
+		t.Errorf("Restricted profile migration failed: expected %d secrets, got %d. Expected: %v, Got: %v",
+			len(expectedSecrets),
+			len(merged.KbsSecretResources),
+			expectedSecrets,
+			merged.KbsSecretResources)
+	}
+}
+
+func TestMergeKbsConfigSpecs_PreservesOtherFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = confidentialcontainersorgv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	r := &TrusteeConfigReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		log:    logr.Discard(),
+	}
+
+	// Test that secret resource merging doesn't affect other fields
+	generatedSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+		KbsConfigMapName:   "generated-config",
+		KbsSecretResources: []string{"attestation-status"},
+		KbsEnvVars: map[string]string{
+			"RUST_LOG": "debug",
+		},
+	}
+
+	manualSpec := confidentialcontainersorgv1alpha1.KbsConfigSpec{
+		KbsConfigMapName:   "manual-config",
+		KbsSecretResources: []string{"my-custom-secret"},
+		KbsEnvVars: map[string]string{
+			"CUSTOM_VAR": "custom_value",
+		},
+	}
+
+	merged := r.mergeKbsConfigSpecs(generatedSpec, manualSpec)
+
+	// Verify secret resources are merged
+	if len(merged.KbsSecretResources) != 2 {
+		t.Errorf("Expected 2 secret resources, got %d: %v",
+			len(merged.KbsSecretResources), merged.KbsSecretResources)
+	}
+
+	// Verify generated ConfigMap name is preserved (manual should not override)
+	if merged.KbsConfigMapName != generatedSpec.KbsConfigMapName {
+		t.Errorf("Expected KbsConfigMapName to be %q, got %q",
+			generatedSpec.KbsConfigMapName, merged.KbsConfigMapName)
+	}
+
+	// Verify env vars are merged
+	if merged.KbsEnvVars["RUST_LOG"] != "debug" {
+		t.Errorf("Expected RUST_LOG env var to be preserved from generated spec")
+	}
+	if merged.KbsEnvVars["CUSTOM_VAR"] != "custom_value" {
+		t.Errorf("Expected CUSTOM_VAR env var to be preserved from manual spec")
+	}
+}


### PR DESCRIPTION
Automatic migration procedure from RH BoT v1.1 to v1.2

- all v1.1 config maps affected by the migration are backed up before the procedure starts
- kbs-config configmap is recreated in the new format making sure the [[plugins]] section is restored as it was in v1.1 (with some 1.2 modifications). The goal is to preserve any customer change in the plugins section, e.g. using vault as secret backend
- reference-values configmap is migrated to new format, i.e. base64 encoded
- cpu/gpu attestation policies are deleted and recreated
- resource policy is deleted and recreated