### PR TITLE
konflux: add PR tags to images for easier identification

### DIFF
--- a/.tekton/trustee-must-gather-pull-request.yaml
+++ b/.tekton/trustee-must-gather-pull-request.yaml
@@ -556,6 +556,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/trustee-operator-bundle-pull-request.yaml
+++ b/.tekton/trustee-operator-bundle-pull-request.yaml
@@ -511,6 +511,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/trustee-operator-pull-request.yaml
+++ b/.tekton/trustee-operator-pull-request.yaml
@@ -554,6 +554,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Tag images with the PR number they were built from, making it easier to identify which image to use for testing before merging.

Two tags are created:
- pr-[PR number]: overridden on each build, tags the latest build
- pullreq-[PR number]-[head commit SHA]: provides history of builds

See https://github.com/openshift/sandboxed-containers-operator/pull/2454 for further reference.