### PR TITLE
release: Update CPE label to 1.102 for release 1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ LABEL vendor="Red Hat, Inc."
 LABEL version="1.2.0"
 LABEL maintainer="Red Hat"
 LABEL io.openshift.tags=""
-LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.101::el9"
+LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9"
 
 # Licenses
 

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -19,7 +19,7 @@ COPY collection-scripts/* /usr/bin/
 
 # Red Hat labels
 LABEL name="openshift-trustee-operator/trustee-must-gather-rhel9" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.101::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9" \
 version="1.2.0" \
 com.redhat.component="redhat-build-of-trustee-must-gather-container" \
 summary="redhat-build-of-trustee-must-gather collects information about RedHat Build of Trustee and its components" \


### PR DESCRIPTION
ProdSec product-definitions registers the Trustee 1.2 stream with CPE version 1.102. This change (1.101 → 1.102) makes our release pipelines to fail at the check-labels check. Update all Dockerfiles to match.