### PR TITLE
release: Update CPE label in bundle.Dockerfile to 1.102

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,7 +36,7 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
-LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.101::el9"
+LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9"
 
 # Licenses
 


### PR DESCRIPTION
ProdSec product-definitions registers the Trustee 1.2 stream with CPE version 1.102. This change (1.101 → 1.102) makes our release pipelines to fail at the check-labels check.

This should have been part of https://github.com/openshift/trustee-operator/pull/358 but it slipped away.

