### PR TITLE
Fix trustee-must-gather label

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=builder /usr/bin/gather /usr/bin/gather_original
 COPY collection-scripts/* /usr/bin/
 
 # Red Hat labels
-LABEL name="openshift-trustee-operator/trustee-must-gather-rhel9" \
+LABEL name="build-of-trustee/trustee-must-gather-rhel9" \
 cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9" \
 version="1.2.0" \
 com.redhat.component="redhat-build-of-trustee-must-gather-container" \


### PR DESCRIPTION
Replaced openshift-trustee-operator/trustee-must-gather-rhel9 with build-of-trustee/trustee-must-gather-rhel9