### PR TITLE
release: Update CPE label to 1.130 (rhocca-1.13) for release 1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ LABEL vendor="Red Hat, Inc."
 LABEL version="1.2.0"
 LABEL maintainer="Red Hat"
 LABEL io.openshift.tags=""
-LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9"
+LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9"
 
 # Licenses
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,7 +36,7 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
-LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9"
+LABEL cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9"
 
 # Licenses
 

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -19,7 +19,7 @@ COPY collection-scripts/* /usr/bin/
 
 # Red Hat labels
 LABEL name="build-of-trustee/trustee-must-gather-rhel9" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.102::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
 version="1.2.0" \
 com.redhat.component="redhat-build-of-trustee-must-gather-container" \
 summary="redhat-build-of-trustee-must-gather collects information about RedHat Build of Trustee and its components" \


### PR DESCRIPTION
Trustee 1.2 is part of the rhocca-1.13 release/support cycle, which covers osc, trustee, and agent-sandbox under a shared update stream. The rhocca-1.13 stream has CPE 1.130 associated with it in ProdSec's product-definitions.