### PR TITLE
Fix infinite loop reconcile

### DIFF
--- a/internal/controller/trusteeconfig_controller.go
+++ b/internal/controller/trusteeconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"sort"
 	"text/template"
 
 	"github.com/go-logr/logr"
@@ -357,11 +358,12 @@ func (r *TrusteeConfigReconciler) mergeKbsConfigSpecs(generatedSpec, manualSpec 
 		secretResourcesMap[secret] = true
 	}
 
-	// Convert map back to slice
+	// Convert map back to slice with stable ordering
 	merged.KbsSecretResources = make([]string, 0, len(secretResourcesMap))
 	for secret := range secretResourcesMap {
 		merged.KbsSecretResources = append(merged.KbsSecretResources, secret)
 	}
+	sort.Strings(merged.KbsSecretResources)
 
 	// Preserve manual local cert cache configuration
 	if len(manualSpec.KbsLocalCertCacheSpec.Secrets) > 0 {


### PR DESCRIPTION
In addition to the upstream fix https://github.com/confidential-containers/trustee-operator/pull/167, the downstream TrusteeConfig controller has a third source of non-determinism that actively changes the KbsConfig CR spec on every reconciliation,
  causing continuous pod restarts.

  Root Cause:

  Non-deterministic KbsSecretResources ordering (trusteeconfig_controller.go, mergeKbsConfigSpecs). Secret resources are deduplicated via a Go map, then converted back to a slice by
  iterating the map. Go map iteration is non-deterministic, so each reconciliation produces a different slice ordering. This is written to the KbsConfig CR, triggering the KbsConfig
  controller to rebuild the deployment with reordered volumes, creating a new ReplicaSet and rolling the pod every cycle.

  Reproduction:

  Configure a TrusteeConfig with 2+ entries in kbsSecretResources. The operator will immediately enter the infinite loop.

  Fix:
  - Sort KbsSecretResources after map-to-slice conversion