### PR TITLE
Add MigrationAnnotation to KbsConfigMap

### DIFF
--- a/internal/controller/trusteeconfig_controller.go
+++ b/internal/controller/trusteeconfig_controller.go
@@ -629,6 +629,9 @@ func (r *TrusteeConfigReconciler) generateKbsConfigMap(ctx context.Context) (*co
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getKbsConfigMapName(),
 			Namespace: r.namespace,
+			Annotations: map[string]string{
+				MigrationAnnotation: MigrationVersion,
+			},
 		},
 		Data: map[string]string{
 			"kbs-config.toml": configToml,


### PR DESCRIPTION
Add annotation at initial creation of the kbs configmap to prevent unnecessary migration during deployment.